### PR TITLE
handle 'up to date' message from newer git versions

### DIFF
--- a/bin/git-play
+++ b/bin/git-play
@@ -173,8 +173,8 @@ try:
                     break
                 except:
                     logging.error('Failed to pull, retry...')
-            # See if something is changed.
-            if rst != 'Already up-to-date.':
+            # See if something is changed. Fix 18/09/2019 handle text response for newer git versions
+            if rst not in  ('Already up to date.', 'Already up-to-date.'):
                 # If it is,
                 logging.info('Something has changed. Applying...')
                 _conf.teardown()


### PR DESCRIPTION
explanation: for git version from Ubuntu 18.04 (EC2 image) the git-play didn't work. The issue was that the response from git after fetching changes was slightly different, and therefore the re-build process was triggered every minute.